### PR TITLE
Add Godot icon to main scene

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)"
+    ],
+    "deny": []
+  }
+}

--- a/godot-ai-test/main.tscn
+++ b/godot-ai-test/main.tscn
@@ -1,3 +1,7 @@
 [gd_scene format=3 uid="uid://r8yip3rec0fu"]
 
 [node name="Node2D" type="Node2D"]
+
+[node name="GodotIcon" type="Sprite2D" parent="."]
+texture = preload("res://icon.svg")
+position = Vector2(576, 324)


### PR DESCRIPTION
## Summary
- Added a Sprite2D node with the Godot icon to the main.tscn scene
- Positioned the icon at the center of the screen (576, 324)

## Test plan
- [ ] Open the project in Godot
- [ ] Run the main scene and verify the Godot icon is displayed at the center
- [ ] Confirm the icon loads properly without errors

🤖 Generated with [Claude Code](https://claude.ai/code)